### PR TITLE
Add rule to named return parameters and add config option to check Stutter

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,16 +46,18 @@ var defaultBadReceiverNames = map[string]bool{
 
 // Config defines configuration options for linter
 type Config struct {
-	Package           bool `json:"package"`
-	Imports           bool `json:"imports"`
-	Names             bool `json:"names"`
-	Exported          bool `json:"exported"`
-	VarDecls          bool `json:"var-decls"`
-	Elses             bool `json:"elses"`
-	MakeSlice         bool `json:"make-slice"`
-	ErrorReturn       bool `json:"error-return"`
-	IgnoredReturn     bool `json:"ignored-return"`
-	PackageUnderscore bool `json:"package-underscore"`
+	Package            bool `json:"package"`
+	Imports            bool `json:"imports"`
+	Names              bool `json:"names"`
+	Exported           bool `json:"exported"`
+	VarDecls           bool `json:"var-decls"`
+	Elses              bool `json:"elses"`
+	MakeSlice          bool `json:"make-slice"`
+	ErrorReturn        bool `json:"error-return"`
+	IgnoredReturn      bool `json:"ignored-return"`
+	PackageUnderscore  bool `json:"package-underscore"`
+	NamedReturn        bool `json:"disallow-named-return"`
+	PackagePrefixNames bool `json:"allow-package-prefix-names"`
 
 	MinConfidence float64 `json:"min-confidence"`
 

--- a/config.go
+++ b/config.go
@@ -46,18 +46,18 @@ var defaultBadReceiverNames = map[string]bool{
 
 // Config defines configuration options for linter
 type Config struct {
-	Package                 bool `json:"package"`
-	Imports                 bool `json:"imports"`
-	Names                   bool `json:"names"`
-	Exported                bool `json:"exported"`
-	VarDecls                bool `json:"var-decls"`
-	Elses                   bool `json:"elses"`
-	MakeSlice               bool `json:"make-slice"`
-	ErrorReturn             bool `json:"error-return"`
-	IgnoredReturn           bool `json:"ignored-return"`
-	PackageUnderscore       bool `json:"package-underscore"`
-	DisallowNamedReturn     bool `json:"disallow-named-return"`
-	AllowPackagePrefixNames bool `json:"allow-package-prefix-names"`
+	Package            bool `json:"package"`
+	Imports            bool `json:"imports"`
+	Names              bool `json:"names"`
+	Exported           bool `json:"exported"`
+	VarDecls           bool `json:"var-decls"`
+	Elses              bool `json:"elses"`
+	MakeSlice          bool `json:"make-slice"`
+	ErrorReturn        bool `json:"error-return"`
+	IgnoredReturn      bool `json:"ignored-return"`
+	PackageUnderscore  bool `json:"package-underscore"`
+	NamedReturn        bool `json:"named-return"`
+	PackagePrefixNames bool `json:"package-prefix-names"`
 
 	MinConfidence float64 `json:"min-confidence"`
 
@@ -77,16 +77,18 @@ type Config struct {
 // NewDefaultConfig creates linter config with predefined options
 func NewDefaultConfig() *Config {
 	return &Config{
-		Package:           true,
-		Imports:           true,
-		Names:             true,
-		Exported:          true,
-		VarDecls:          true,
-		Elses:             true,
-		MakeSlice:         true,
-		ErrorReturn:       true,
-		IgnoredReturn:     true,
-		PackageUnderscore: true,
+		Package:            true,
+		Imports:            true,
+		Names:              true,
+		Exported:           true,
+		VarDecls:           true,
+		Elses:              true,
+		MakeSlice:          true,
+		ErrorReturn:        true,
+		IgnoredReturn:      true,
+		PackageUnderscore:  true,
+		NamedReturn:        false,
+		PackagePrefixNames: false,
 
 		MinConfidence:    0.8,
 		Initialisms:      defaultCommonInitialisms,

--- a/config.go
+++ b/config.go
@@ -46,18 +46,18 @@ var defaultBadReceiverNames = map[string]bool{
 
 // Config defines configuration options for linter
 type Config struct {
-	Package            bool `json:"package"`
-	Imports            bool `json:"imports"`
-	Names              bool `json:"names"`
-	Exported           bool `json:"exported"`
-	VarDecls           bool `json:"var-decls"`
-	Elses              bool `json:"elses"`
-	MakeSlice          bool `json:"make-slice"`
-	ErrorReturn        bool `json:"error-return"`
-	IgnoredReturn      bool `json:"ignored-return"`
-	PackageUnderscore  bool `json:"package-underscore"`
-	NamedReturn        bool `json:"disallow-named-return"`
-	PackagePrefixNames bool `json:"allow-package-prefix-names"`
+	Package                 bool `json:"package"`
+	Imports                 bool `json:"imports"`
+	Names                   bool `json:"names"`
+	Exported                bool `json:"exported"`
+	VarDecls                bool `json:"var-decls"`
+	Elses                   bool `json:"elses"`
+	MakeSlice               bool `json:"make-slice"`
+	ErrorReturn             bool `json:"error-return"`
+	IgnoredReturn           bool `json:"ignored-return"`
+	PackageUnderscore       bool `json:"package-underscore"`
+	DisallowNamedReturn     bool `json:"disallow-named-return"`
+	AllowPackagePrefixNames bool `json:"allow-package-prefix-names"`
 
 	MinConfidence float64 `json:"min-confidence"`
 

--- a/lint.go
+++ b/lint.go
@@ -92,7 +92,7 @@ func (f *file) lint() []Problem {
 	}
 
 	if f.config.Exported {
-		f.lintExported(f.config.AllowPackagePrefixNames)
+		f.lintExported(f.config.PackagePrefixNames)
 	}
 	if f.config.Names {
 		f.lintNames()
@@ -124,7 +124,7 @@ func (f *file) lint() []Problem {
 		f.lintIgnoredReturn()
 	}
 
-	if f.config.DisallowNamedReturn {
+	if f.config.NamedReturn {
 		f.lintNamedReturn()
 	}
 

--- a/testdata/return-values.go
+++ b/testdata/return-values.go
@@ -1,0 +1,46 @@
+// Test that return values has no names
+
+// Package foo ...
+package foo
+
+func f1() (x int) { // MATCH /return value.*should not be named/
+	return 0
+}
+
+func f2() (x, y int) { // MATCH /return value.*should not be named/
+	return 0, 0
+}
+
+func f3() (x int, y int) { // MATCH /return value.*should not be named/
+	return 0, 0
+}
+
+func f4() (int, y int) { // MATCH /return value.*should not be named/
+	return 0, 0
+}
+
+type ret struct{}
+
+func (r ret) f5() (x int) { // MATCH /return value.*should not be named/
+	return 0
+}
+
+func (r ret) f6() (x, y int) { // MATCH /return value.*should not be named/
+	return 0, 0
+}
+
+func (r ret) f7() (x int, y int) { // MATCH /return value.*should not be named/
+	return 0, 0
+}
+
+func (r ret) f8() (int, y int) { // MATCH /return value.*should not be named/
+	return 0, 0
+}
+
+func (r ret) f9() (int int) { // MATCH /return value.*should not be named/
+	return 0, 0
+}
+
+func (r ret) f10() (int, y int) { // MATCH /return value.*should not be named/
+	return 0, 0
+}


### PR DESCRIPTION
Good day!
There are two additions: taken out variable settings for checking the names of variables, if they begin with the name of the package; and added a check on the use of named return values. I think that this test should be added, because when you use named parameters, you can create very difficult to perceptible errors when, by mistake or misspelling, use "=" instead of "=" - thus there will be shadowing variables and will not give any error, because the returned variable is already initialized.