### PR TITLE
No errors on interface declaration

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -732,6 +732,15 @@ func (f *file) lintVarDecls() {
 			if defType, ok := isUntypedConst(rhs); ok && !isIdent(v.Type, defType) {
 				return false
 			}
+
+			// Rough check of the interface type(LHS type != RHS type)
+			if rhsV, ok := rhs.(*ast.CompositeLit); ok && v.Type != rhsV.Type {
+				return false
+			}
+			if _, ok := rhs.(*ast.Ident); ok {
+				return false
+			}
+
 			f.errorf(v.Type, 0.8, category("type-inference"), "should omit type %s from declaration of var %s; it will be inferred from the right-hand side", f.render(v.Type), v.Names[0])
 			return false
 		}

--- a/testdata/var-decl.go
+++ b/testdata/var-decl.go
@@ -44,5 +44,11 @@ var floatV floatT = 123.45
 // No warning because the LHS names an interface type.
 var data interface{} = googleIPs
 
+// No warning because the LHS names an interface type.
+var data IType = googleIPs{}
+
+// No warning because the LHS names an interface type.
+var data IType = googleIPs
+
 // No warning because it's a common idiom for interface satisfaction.
 var _ Server = (*serverImpl)(nil)


### PR DESCRIPTION
Some fix to prevent errors on variable declaration like this one:
var data InterfaceType = someType{}