### PR TITLE
'go install' fix to directory structure

### DIFF
--- a/cmd/gohint/gohint.go
+++ b/cmd/gohint/gohint.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/wlbr/hint"
+	"github.com/elgris/hint"
 )
 
 var reporterName = flag.String("reporter", "plain", "name of reported to generate ouput. Available: plain, checkstyle")

--- a/cmd/gohint/gohint.go
+++ b/cmd/gohint/gohint.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/elgris/hint"
+	"github.com/wlbr/hint"
 )
 
 var reporterName = flag.String("reporter", "plain", "name of reported to generate ouput. Available: plain, checkstyle")


### PR DESCRIPTION
Hi, the current folder layout does not allow that the tool is installed automatically to GOBIN by 'go install'.  A minimal change in the structure enables this.